### PR TITLE
ci(security): reduce workflows permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,6 +16,8 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # TODO: googleapis/release-please-action cannot sign commits yet.
       #   We'll use the cli until there's a fix for

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,9 +3,14 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   release-publish-artifacts:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Set by default the permission to read-all in all the workflows and add the proper permissions for the following workflows:

* CI
* release-please
* Release Publish Artifacts

closes #352